### PR TITLE
Update Cauris logo and description (#490)

### DIFF
--- a/metadata/0x3B03863BD553C4CE07eABF2278016533451c9101.json
+++ b/metadata/0x3B03863BD553C4CE07eABF2278016533451c9101.json
@@ -37,7 +37,7 @@
     "slug": "cauris-fintech-1",
     "description": "Cauris is a DeFi debt fund with the mission of giving access to capital to 100 million people across the world. The pool seeks to generate uncorrelated and excess risk-adjusted returns to its investors by providing secured loans to fintechs that lend to consumers and small businesses in the Global South and Europe. Cauris was founded in 2021 and has since originated over $5M in loans that impacted over 300,000 borrowers. This Tinlake pool will consist of tranches of secured debentures with maturities ranging from one to three years.",
     "media": {
-      "logo": "https://storage.googleapis.com/tinlake/pool-media/cauris-1/logo3.svg",
+      "logo": "https://storage.googleapis.com/tinlake/pool-media/cauris-1/logo.svg",
       "icon": "https://storage.googleapis.com/tinlake/pool-media/cauris-1/icon.svg",
       "drop": "https://storage.googleapis.com/tinlake/pool-media/cauris-1/drop.svg",
       "tin": "https://storage.googleapis.com/tinlake/pool-media/cauris-1/tin.svg"


### PR DESCRIPTION
Update Cauris logo and description. The logo svg wasn't displaying correctly in Chrome due to a `:` in an `id` attribute, which [Figma seems to add](https://forum.figma.com/t/svg-export-for-lineargradients-with-colons-in-id-showing-blank-in-chrome/9109)