### PR TITLE
Add client profiles to metadata links

### DIFF
--- a/metadata/0x4cA805cE8EcE2E63FfC1F9f8F2731D3F48DF89Df.json
+++ b/metadata/0x4cA805cE8EcE2E63FfC1F9f8F2731D3F48DF89Df.json
@@ -48,7 +48,8 @@
       "Links": {
         "Executive Summary": "https://storage.googleapis.com/tinlake/docs/summaries/HTC2.pdf",
         "Forum Discussion": "https://gov.centrifuge.io/t/community-introduction-harbor-trade-credit/141",
-        "Website": "https://harbortradecredit.com/"
+        "Website": "https://harbortradecredit.com/",
+        "Client Profiles": "https://cdn.harbortrade.com/static/assets/investors/resources/client-profiles.pdf"
       }
     },
     "maker": {


### PR DESCRIPTION
Add a new link to harbor trade's client profiles pdf on the tinlake ui